### PR TITLE
fix: update default pages parameter in translation cron job

### DIFF
--- a/.github/workflows/translate-cron.yml
+++ b/.github/workflows/translate-cron.yml
@@ -42,7 +42,7 @@ jobs:
         id: inputs
         run: |
           LOCALE="${{ github.event.inputs.locale || 'en' }}"
-          PAGES="${{ github.event.inputs.pages || '5' }}"
+          PAGES="${{ github.event.inputs.pages || '2' }}"
           echo "locale=$LOCALE" >> "$GITHUB_OUTPUT"
           echo "pages=$PAGES"   >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
- Changed the default value of the pages parameter from 5 to 2 in the translation cron job workflow, optimizing the translation process for efficiency.